### PR TITLE
2 core features crud routing api forms

### DIFF
--- a/recipe-manager/src/app/app.component.css
+++ b/recipe-manager/src/app/app.component.css
@@ -1,0 +1,12 @@
+.drawer-container {
+  border: 1px solid var(--dark-border);
+  display: grid;
+  min-height: 100vh;
+  background: var(--primary-bg);
+}
+
+@media (max-width: 600px) {
+  .drawer-container {
+    grid-template-columns: 1fr;
+  }
+}

--- a/recipe-manager/src/app/app.component.css
+++ b/recipe-manager/src/app/app.component.css
@@ -1,12 +1,10 @@
 .drawer-container {
   border: 1px solid var(--dark-border);
-  display: grid;
   min-height: 100vh;
   background: var(--primary-bg);
 }
 
-@media (max-width: 600px) {
-  .drawer-container {
-    grid-template-columns: 1fr;
-  }
+.main-content {
+  padding-top: 64px;
+  padding-bottom: 32px;
 }

--- a/recipe-manager/src/app/app.component.html
+++ b/recipe-manager/src/app/app.component.html
@@ -1,7 +1,20 @@
 <mat-drawer-container class="drawer-container" autosize>
-  <app-header />
-  <app-dashboard>
-    <app-recipe-card />
-  </app-dashboard>
+  <!-- sidebar (mat-drawer) -->
+  <mat-drawer
+    #drawer
+    class="sidebar"
+    [mode]="isSmallScreen ? 'over' : 'side'"
+    [opened]="!isSmallScreen"
+  >
+    <app-sidebar />
+  </mat-drawer>
+  <!-- main content -->
+  <div class="main-content">
+    <app-header [drawer]="drawer" />
+    <!-- <router-outlet> -->
+    <app-dashboard> <app-recipe-card /></app-dashboard>
+    <!-- </router-outlet> -->
+    <!-- TODO dynamically load main content via routing once ready - defaulting to dashboard for now -->
+  </div>
 </mat-drawer-container>
 <app-footer />

--- a/recipe-manager/src/app/app.component.html
+++ b/recipe-manager/src/app/app.component.html
@@ -1,5 +1,7 @@
-<app-header />
-<app-dashboard>
-  <app-recipe-card />
-</app-dashboard>
+<mat-drawer-container class="drawer-container" autosize>
+  <app-header />
+  <app-dashboard>
+    <app-recipe-card />
+  </app-dashboard>
+</mat-drawer-container>
 <app-footer />

--- a/recipe-manager/src/app/app.component.ts
+++ b/recipe-manager/src/app/app.component.ts
@@ -1,9 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { HeaderComponent } from './shared/layout/header/header.component';
 import { FooterComponent } from './shared/layout/footer/footer.component';
 import { RecipeCardComponent } from './shared/layout/recipe-card/recipe-card.component';
 import { SharedModule } from './shared/shared.module';
+import { SidebarComponent } from './shared/layout/sidebar/sidebar.component';
+import { MatDrawer } from '@angular/material/sidenav';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 
 @Component({
   selector: 'app-root',
@@ -13,10 +16,28 @@ import { SharedModule } from './shared/shared.module';
     FooterComponent,
     DashboardComponent,
     RecipeCardComponent,
+    SidebarComponent,
   ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css',
 })
 export class AppComponent {
   title = 'recipe-manager';
+
+  @ViewChild('drawer') drawer!: MatDrawer;
+
+  isSmallScreen = false;
+
+  constructor(private breakpointObserver: BreakpointObserver) {
+    // listen for screen size changes
+    this.breakpointObserver
+      .observe([Breakpoints.Handset, Breakpoints.Tablet])
+      .subscribe((result) => {
+        this.isSmallScreen = result.matches;
+        // close the drawer optionally on mobile
+        if (this.drawer && this.isSmallScreen) {
+          this.drawer.close();
+        }
+      });
+  }
 }

--- a/recipe-manager/src/app/app.component.ts
+++ b/recipe-manager/src/app/app.component.ts
@@ -3,10 +3,12 @@ import { DashboardComponent } from './dashboard/dashboard.component';
 import { HeaderComponent } from './shared/layout/header/header.component';
 import { FooterComponent } from './shared/layout/footer/footer.component';
 import { RecipeCardComponent } from './shared/layout/recipe-card/recipe-card.component';
+import { SharedModule } from './shared/shared.module';
 
 @Component({
   selector: 'app-root',
   imports: [
+    SharedModule,
     HeaderComponent,
     FooterComponent,
     DashboardComponent,

--- a/recipe-manager/src/app/app.component.ts
+++ b/recipe-manager/src/app/app.component.ts
@@ -19,7 +19,10 @@ import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
     SidebarComponent,
   ],
   templateUrl: './app.component.html',
-  styleUrl: './app.component.css',
+  styleUrls: [
+    './app.component.css',
+    './shared/layout/sidebar/sidebar.component.css',
+  ],
 })
 export class AppComponent {
   title = 'recipe-manager';

--- a/recipe-manager/src/app/dashboard/dashboard.component.css
+++ b/recipe-manager/src/app/dashboard/dashboard.component.css
@@ -4,26 +4,13 @@ body {
   margin: 0;
 }
 
-.dashboard-container {
-  border: 1px solid var(--dark-border);
-  display: grid;
-  min-height: 100vh;
-  background: var(--primary-bg);
-}
-
 .dashboard-main {
   padding: 2.2rem 2.5rem;
   background: var(--primary-bg);
 }
 
-.recipe-cards {
+.recipe-cards-container {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 1.6rem;
-}
-
-@media (max-width: 600px) {
-  .dashboard-container {
-    grid-template-columns: 1fr;
-  }
 }

--- a/recipe-manager/src/app/dashboard/dashboard.component.html
+++ b/recipe-manager/src/app/dashboard/dashboard.component.html
@@ -1,13 +1,5 @@
-<mat-drawer-container class="dashboard-container" autosize>
-  <!-- Angular Material Sidenav -->
-  <mat-drawer #drawer class="sidebar" mode="side"> <app-sidebar /> </mat-drawer>
-  <!-- Main dashboard content -->
-  <main class="dashboard-main">
-    <div class="toggle-menu">
-      <button type="button" mat-button (click)="drawer.toggle()">Menu</button>
-    </div>
-    <section class="recipe-cards">
-      <ng-content select="app-recipe-card" />
-    </section>
-  </main>
-</mat-drawer-container>
+<main class="dashboard-main">
+  <section class="recipe-cards-container">
+    <ng-content select="app-recipe-card" />
+  </section>
+</main>

--- a/recipe-manager/src/app/dashboard/dashboard.component.ts
+++ b/recipe-manager/src/app/dashboard/dashboard.component.ts
@@ -1,10 +1,9 @@
 import { Component } from '@angular/core';
 import { SharedModule } from '../shared/shared.module';
-import { SidebarComponent } from '../shared/layout/sidebar/sidebar.component';
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [SidebarComponent, SharedModule],
+  imports: [SharedModule],
   templateUrl: './dashboard.component.html',
   styleUrls: [
     './dashboard.component.css',

--- a/recipe-manager/src/app/shared/layout/header-footer.component.css
+++ b/recipe-manager/src/app/shared/layout/header-footer.component.css
@@ -13,6 +13,10 @@
   border-bottom: 1px solid #ebdfd0;
 }
 
+.header-spacer {
+  flex: 1 1 auto;
+}
+
 .footer {
   grid-column: 1 / -1;
   font-size: var(--font-size-sm);

--- a/recipe-manager/src/app/shared/layout/header-footer.component.css
+++ b/recipe-manager/src/app/shared/layout/header-footer.component.css
@@ -7,10 +7,14 @@
 }
 
 .header {
-  grid-column: 1 / -1;
   font-size: 1.6rem;
   letter-spacing: 0.5px;
   border-bottom: 1px solid #ebdfd0;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1001;
 }
 
 .header-spacer {
@@ -18,8 +22,12 @@
 }
 
 .footer {
-  grid-column: 1 / -1;
   font-size: var(--font-size-sm);
   border-top: 1px solid #ebdfd0;
   text-align: center;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1001;
 }

--- a/recipe-manager/src/app/shared/layout/header/header.component.html
+++ b/recipe-manager/src/app/shared/layout/header/header.component.html
@@ -1,1 +1,23 @@
-<header class="header">My Recipes</header>
+<mat-toolbar class="header">
+  <button matIconButton class="icon" matTooltip="Menu" aria-label="Menu button">
+    <mat-icon>menu</mat-icon>
+  </button>
+  <span>My Recipe Manager</span>
+  <span class="header-spacer"></span>
+  <button
+    matIconButton
+    class="icon favorite-icon"
+    matTooltip="Favorites"
+    aria-label="Favorite button"
+  >
+    <mat-icon>favorite</mat-icon>
+  </button>
+  <button
+    matIconButton
+    class="icon"
+    matTooltip="Share"
+    aria-label="Share button"
+  >
+    <mat-icon>share</mat-icon>
+  </button>
+</mat-toolbar>

--- a/recipe-manager/src/app/shared/layout/header/header.component.html
+++ b/recipe-manager/src/app/shared/layout/header/header.component.html
@@ -28,4 +28,3 @@
     <mat-icon>share</mat-icon>
   </button>
 </mat-toolbar>
-<mat-drawer #drawer class="sidebar" mode="side"> <app-sidebar /> </mat-drawer>

--- a/recipe-manager/src/app/shared/layout/header/header.component.html
+++ b/recipe-manager/src/app/shared/layout/header/header.component.html
@@ -1,5 +1,12 @@
 <mat-toolbar class="header">
-  <button matIconButton class="icon" matTooltip="Menu" aria-label="Menu button">
+  <button
+    type="button"
+    matIconButton
+    (click)="drawer.toggle()"
+    class="icon toggle-menu"
+    matTooltip="Menu"
+    aria-label="Menu button"
+  >
     <mat-icon>menu</mat-icon>
   </button>
   <span>My Recipe Manager</span>
@@ -21,3 +28,4 @@
     <mat-icon>share</mat-icon>
   </button>
 </mat-toolbar>
+<mat-drawer #drawer class="sidebar" mode="side"> <app-sidebar /> </mat-drawer>

--- a/recipe-manager/src/app/shared/layout/header/header.component.ts
+++ b/recipe-manager/src/app/shared/layout/header/header.component.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { SharedModule } from '../../shared.module';
+import { SidebarComponent } from '../sidebar/sidebar.component';
 
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [SharedModule],
+  imports: [SharedModule, SidebarComponent],
   templateUrl: './header.component.html',
   styleUrl: '../header-footer.component.css',
 })

--- a/recipe-manager/src/app/shared/layout/header/header.component.ts
+++ b/recipe-manager/src/app/shared/layout/header/header.component.ts
@@ -1,12 +1,14 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { SharedModule } from '../../shared.module';
-import { SidebarComponent } from '../sidebar/sidebar.component';
+import { MatDrawer } from '@angular/material/sidenav';
 
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [SharedModule, SidebarComponent],
+  imports: [SharedModule],
   templateUrl: './header.component.html',
   styleUrl: '../header-footer.component.css',
 })
-export class HeaderComponent {}
+export class HeaderComponent {
+  @Input() drawer!: MatDrawer; // take drawer from parent
+}

--- a/recipe-manager/src/app/shared/layout/sidebar/sidebar.component.css
+++ b/recipe-manager/src/app/shared/layout/sidebar/sidebar.component.css
@@ -3,10 +3,10 @@
   padding: 20px;
   box-shadow: 2px 0 16px rgba(0, 0, 0, 0.04);
   min-width: 220px;
+  width: 260px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  transition: all 0.3s;
 }
 
 .sidebar h2 {
@@ -49,9 +49,11 @@
   background: var(--accent);
   color: #fff;
 }
-@media (max-width: 600px) {
+
+@media (max-width: 900px) {
   .sidebar {
-    min-width: 100%;
+    width: 100%;
+    min-width: unset;
     padding: 1rem;
   }
 }

--- a/recipe-manager/src/app/shared/layout/sidebar/sidebar.component.css
+++ b/recipe-manager/src/app/shared/layout/sidebar/sidebar.component.css
@@ -1,11 +1,3 @@
-.toggle-menu {
-  display: none;
-  display: flex;
-  height: 100%;
-  align-items: center;
-  justify-content: center;
-}
-
 .sidebar {
   background: var(--sidebar-bg);
   padding: 20px;
@@ -61,12 +53,5 @@
   .sidebar {
     min-width: 100%;
     padding: 1rem;
-  }
-}
-
-@media (max-width: 900px) {
-  .toggle-menu {
-    display: block;
-    margin: 1rem;
   }
 }

--- a/recipe-manager/src/app/shared/layout/sidebar/sidebar.component.html
+++ b/recipe-manager/src/app/shared/layout/sidebar/sidebar.component.html
@@ -1,4 +1,4 @@
-<div #drawer class="sidebar" mode="side">
+<div class="sidebar">
   <h2>Recipe Organizer</h2>
   <nav>
     <a href="#">Home</a>

--- a/recipe-manager/src/app/shared/shared.module.ts
+++ b/recipe-manager/src/app/shared/shared.module.ts
@@ -3,10 +3,29 @@ import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { FormsModule } from '@angular/forms';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
   declarations: [],
-  imports: [CommonModule, MatSidenavModule, MatButtonModule, FormsModule],
-  exports: [CommonModule, MatSidenavModule, MatButtonModule, FormsModule],
+  imports: [
+    CommonModule,
+    MatSidenavModule,
+    MatButtonModule,
+    FormsModule,
+    MatToolbarModule,
+    MatIconModule,
+    MatTooltipModule,
+  ],
+  exports: [
+    CommonModule,
+    MatSidenavModule,
+    MatButtonModule,
+    FormsModule,
+    MatToolbarModule,
+    MatIconModule,
+    MatTooltipModule,
+  ],
 })
 export class SharedModule {}

--- a/recipe-manager/src/styles.css
+++ b/recipe-manager/src/styles.css
@@ -1,12 +1,4 @@
-html,
-body {
-  height: 100%;
-}
-body {
-  margin: 0;
-  font-family: Roboto, "Helvetica Neue", sans-serif;
-}
-
+/* global color palette */
 :root {
   --primary-bg: #f8f6f3;
   --sidebar-bg: #f3eadd;
@@ -20,4 +12,31 @@ body {
   --font-size-lg: 1.25rem;
   --font-size-md: 1rem;
   --font-size-sm: 0.92rem;
+  --font-color-std: #61361f;
+  --font-color-bright: #623f27;
+}
+
+/* global styling ruleset for consistency */
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: Roboto, "Helvetica Neue", sans-serif;
+}
+
+button {
+  cursor: pointer;
+}
+
+button.icon {
+  background: none;
+  border: none;
+  color: var(--font-color-std);
+}
+
+button.icon:hover {
+  color: var(--font-color-bright);
 }

--- a/recipe-manager/src/styles.css
+++ b/recipe-manager/src/styles.css
@@ -40,3 +40,10 @@ button.icon {
 button.icon:hover {
   color: var(--font-color-bright);
 }
+
+.mat-drawer {
+  top: 64px !important; /* match header height */
+  height: calc(
+    100vh - 120px
+  ) !important; /*sidebar height to match amin content's*/
+}


### PR DESCRIPTION
Finalized mat-toolbar set up for persistent layout (header/sidebar/footer always visible). May come back to refine styling further,